### PR TITLE
Updated installation scripts

### DIFF
--- a/linux_setup.sh
+++ b/linux_setup.sh
@@ -2,12 +2,13 @@
 
 # Download and unzip Eigen because Eigen does ont have an official github repo
 # that we can add as a submodule.
-wget http://bitbucket.org/eigen/eigen/get/3.3.4.zip --header "Referer: bitbucket.org"
+wget https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip --header "Referer: gitlab.com"
 
-unzip 3.3.4.zip -d externals
+
+unzip eigen-3.3.4.zip -d externals
 # Rename the folder.
-mv externals/eigen-eigen-5a0156e40feb externals/eigen
-rm 3.3.4.zip
+mv externals/eigen-3.3.4 externals/eigen
+rm eigen-3.3.4.zip
 
 # Download and unzip GLEW because building from the source is a huge pain, as
 # suggested in their website.

--- a/macos_setup.sh
+++ b/macos_setup.sh
@@ -2,11 +2,11 @@
 
 # Download and unzip Eigen because Eigen does ont have an official github repo
 # that we can add as a submodule.
-curl -LOk http://bitbucket.org/eigen/eigen/get/3.3.4.zip
-unzip 3.3.4.zip -d externals
+curl -LOk https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip
+unzip eigen-3.3.4.zip -d externals
 # Rename the folder.
-mv externals/eigen-eigen-5a0156e40feb externals/eigen
-rm 3.3.4.zip
+mv externals/eigen-3.3.4 externals/eigen
+rm eigen-3.3.4.zip
 
 # Download and unzip GLEW because building from the source is a huge pain, as
 # suggested in their website.


### PR DESCRIPTION
Required eigen 3.3.4 has been moved from Bitbucket to Gitlab. I have updated the scripts for Linux and macOS. This will also fix this [issue](https://github.com/mit-gfx/multicopter_design/issues/15). @dut09 Please review.